### PR TITLE
Remove Promise polyfill and use native Promise

### DIFF
--- a/lib/handler_creator.js
+++ b/lib/handler_creator.js
@@ -10,7 +10,7 @@
 
     var _ = require("./utils/smalldash");
     var resolveKeys = require("./utils/resolve_keys");
-    var Promise = require("es6-promise").Promise;
+    var Promise = window.Promise;
     var makeRouteCreator = require("./route_creator");
 
     // TODO expose this debugging as a flag at the top level router options

--- a/lib/route_creator.js
+++ b/lib/route_creator.js
@@ -1,7 +1,7 @@
 (function (define) { 'use strict';
   define(function (require) {
 
-    var Promise = require("es6-promise").Promise;
+    var Promise = window.Promise;
 
     return function routeCreator(router) {
       var cache = {};

--- a/lib/utils/resolve_keys.js
+++ b/lib/utils/resolve_keys.js
@@ -1,7 +1,7 @@
 (function (define) { 'use strict';
   define(function (require) {
 
-    var Promise = require("es6-promise").Promise;
+    var Promise = window.Promise;
 
     return function resolveKeys(obj) {
       if (!obj) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cherrytree",
-  "version": "0.7.0",
+  "version": "0.7.2",
   "description": "Cherrytree is a hierarchical router for clientside web applications.",
   "main": "router",
   "scripts": {
@@ -28,7 +28,6 @@
   ],
   "devDependencies": {
     "chai": "~1.8.0",
-    "es6-promise": "latest",
     "jquery": "^2.1.1",
     "karma": "~0.12.23",
     "karma-chrome-launcher": "~0.1.0",

--- a/vendor/router.js
+++ b/vendor/router.js
@@ -2153,6 +2153,6 @@ define("route-recognizer", [], function() { return {"default": RouteRecognizer};
 define("rsvp", [], function() { return RSVP;});
 define("rsvp/promise", [], function() { return {"default": RSVP}; });
 return requireModule('router')["default"];
-}(window, require("es6-promise").Promise, require("./route-recognizer")));
+}(window, window.Promise, require("./route-recognizer")));
 });
 })(typeof define === 'function' && define.amd ? define : function (factory) { module.exports = factory(require); });


### PR DESCRIPTION
This will remove the Promise polyfill. These polyfills are added in our main projects (if required) and do not need to be inserted in a library of a library